### PR TITLE
Reduce margin-bottom of .clients section to 0px

### DIFF
--- a/assets/css/_about.scss
+++ b/assets/css/_about.scss
@@ -64,7 +64,7 @@
   }
 
   .clients {
-    margin-bottom: 150px;
+    margin-bottom: 0px;
     .gallery-cell {
       width: 100%;
       min-height: 250px;


### PR DESCRIPTION
To keep the consistency of margin-bottom white space throughout each section of this page. I calculated the bottom white space above the first testimony section, and according to what I came up with, it was 70px.

Reducing the margin-bottom from the clients section, aesthetically looks better on mobile and desktop, but also the spacing is the same as well ( margin-bottom from .img = 30px + margin-bottom from second div.testimonial = 40px = 70px ).